### PR TITLE
Update package.json templates to point to correct github repo

### DIFF
--- a/client/proto-ts/stub/package.json.chain-api.template
+++ b/client/proto-ts/stub/package.json.chain-api.template
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/InjectiveLabs/injective-core.git"
+    "url": "git+https://github.com/InjectiveFoundation/injective-core.git"
   },
   "keywords": [
     "injective-core",
@@ -17,9 +17,9 @@
   "author": "Injective Labs",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/InjectiveLabs/injective-core/issues"
+    "url": "https://github.com/InjectiveFoundation/injective-core/issues"
   },
-  "homepage": "https://github.com/InjectiveLabs/injective-core#readme",
+  "homepage": "https://github.com/InjectiveFoundation/injective-core#readme",
   "dependencies": {
     "@injectivelabs/grpc-web": "^0.0.1",
     "google-protobuf": "^3.13.0"

--- a/client/proto-ts/stub/package.json.core-proto-ts.template
+++ b/client/proto-ts/stub/package.json.core-proto-ts.template
@@ -10,7 +10,7 @@
   "module": "./esm/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/InjectiveLabs/injective-core.git"
+    "url": "git+https://github.com/InjectiveFoundation/injective-core.git"
   },
   "keywords": [
     "injective-core",
@@ -20,9 +20,9 @@
   "author": "Injective Labs",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/InjectiveLabs/injective-core/issues"
+    "url": "https://github.com/InjectiveFoundation/injective-core/issues"
   },
-  "homepage": "https://github.com/InjectiveLabs/injective-core#readme",
+  "homepage": "https://github.com/InjectiveFoundation/injective-core#readme",
   "dependencies": {
     "@injectivelabs/grpc-web": "^0.0.1",
     "google-protobuf": "^3.14.0",


### PR DESCRIPTION
Current NPM packages still point to the repo under InjectiveLabs, which is now status code 404.