### PR TITLE
Fixed new ledger devices not detected when using the --ledger flag

### DIFF
--- a/injective-chain/crypto/ledger/hub/hub.go
+++ b/injective-chain/crypto/ledger/hub/hub.go
@@ -33,10 +33,16 @@ var (
 
 		// Original product IDs
 		0x0000, /* Ledger Blue */
-		0x0001, /* Ledger Nano S */
-		0x0004, /* Ledger Nano X */
-		0x0005, /* Ledger Nano S Plus */
-		0x0006, /* Ledger Nano FTS */
+		0x0001, /* Ledger Nano S Legacy */
+		0x1000, /* Ledger Nano S */
+		0x0004, /* Ledger Nano X Legacy */
+		0x4000, /* Ledger Nano X */
+		0x0005, /* Ledger Nano S Plus Legacy */
+		0x5000, /* Ledger Nano S Plus */
+		0x0006, /* Ledger Stax Legacy */
+		0x6000, /* Ledger Stax */
+		0x0007, /* Ledger Flex Legacy */
+		0x7000, /* Ledger Flex */
 
 		0x0015, /* HID + U2F + WebUSB Ledger Blue */
 		0x1015, /* HID + U2F + WebUSB Ledger Nano S */


### PR DESCRIPTION
It seems Ledger has added new product ids for new Ledger devices. By checking [LedgerLive's device detection code](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/devices/src/index.ts), we can retrieve the new ones. The logic is much more convoluted in LedgerLive (for some unknown reason), but essentially the new product ID is the old one with 12 bits shifted to the left (eg. Nano X is both 0x0004 and 0x4000). You can verify this in the LedgerLive code (productIdMM value and bit shifting).

I've added the new product ids in the corresponding list and now new Ledger devices work correctly with injectived.